### PR TITLE
Benchmark against non-streaming json loader

### DIFF
--- a/json_stream_rs_tokenizer/benchmark/random_json_generator.py
+++ b/json_stream_rs_tokenizer/benchmark/random_json_generator.py
@@ -37,8 +37,10 @@ class RandomJsonGenerator:
             while bytes_here < max_bytes:
                 if bytes_here > 2:  # i.e. not first
                     bytes_here += 2  # ", "
+                elems_left = n_elems-len(l)
+                bytes_left = max_bytes-bytes_here
                 elem, elem_bytes = random.choice(elem_types)(
-                    depth + 1, max_bytes / n_elems
+                    depth + 1, bytes_left / (elems_left or -1)
                 )
                 bytes_here += elem_bytes
                 l.append(elem)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "json-stream-rs-tokenizer"
-version = "0.2.0"
+version = "0.2.1"
 description = "A faster tokenizer for the json-stream Python library"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Also hit the target length of the top-level random JSON list with greater accuracy.

Fixes #6 