### PR TITLE
Allow large integers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ name = "json_stream_rs_tokenizer"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.16.5", features = ["extension-module"] }
+num-bigint = "0.4.3"
+pyo3 = { version = "0.16.5", features = ["extension-module", "num-bigint"] }
 pyo3-file = "0.5.0"
 utf8-chars = "2.0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pyo3-file = "0.5.0"
 utf8-chars = "2.0.2"
 
 [build-dependencies]
-pyo3-build-config = "0.17.1"
+pyo3-build-config = { version = "0.17.1", features = ["resolve-config"] }
 
 [patch.crates-io.pyo3-file]
 git = 'https://github.com/smheidrich/pyo3-file.git'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ pyo3 = { version = "0.16.5", features = ["extension-module", "num-bigint"] }
 pyo3-file = "0.5.0"
 utf8-chars = "2.0.2"
 
+[build-dependencies]
+pyo3-build-config = "0.17.1"
+
 [patch.crates-io.pyo3-file]
 git = 'https://github.com/smheidrich/pyo3-file.git'
 branch = 'divide-buf-length-by-4-to-fix-textio-bug'

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ for k, l in d.items():
 ```
 
 As a perhaps slightly more convenient alternative, the package also provides
-wrappers around json_stream's `load` and `visit` functions that do it for you:
+wrappers around json_stream's `load` and `visit` functions which do this for
+you:
 
 ```python
 from json_stream_rs_tokenizer import load
@@ -56,6 +57,13 @@ d = load(StringIO('{ "a": [1,2,3,4], "b": [5,6,7] }'))
 
 # ...
 ```
+
+## Limitations
+
+- Arbitrary-size integers are not supported for PyPy nor when the extension is
+  built against Python's limited C API (`Py_LIMITED_API`). This is due to a
+  limitation of PyO3's
+  [`num-bigint` extension](https://pyo3.rs/main/doc/pyo3/num_bigint/).
 
 ## Benchmarks
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Required for PyO3-specific options in #cfg[...] conditions
+    pyo3_build_config::use_pyo3_cfgs();
+}

--- a/src/int.rs
+++ b/src/int.rs
@@ -12,6 +12,7 @@ pub struct ParseIntError {
 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
 use num_bigint::BigInt;
 
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
 pub enum AppropriateInt {
     Normal(i64),
     Big(BigInt),
@@ -39,7 +40,7 @@ impl FromStr for AppropriateInt {
                 }
                 #[cfg(any(Py_LIMITED_API, PyPy))]
                 {
-                    e
+                    Err(ParseIntError{message: format!("{e:?}")})
                 }
             }
             Err(e) => {
@@ -51,7 +52,7 @@ impl FromStr for AppropriateInt {
 
 impl IntoPy<PyObject> for AppropriateInt {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        #![cfg(not(any(Py_LIMITED_API, PyPy)))]
+        #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         match self {
             AppropriateInt::Normal(num) => { num.into_py(py) },
             AppropriateInt::Big(num) => { num.into_py(py) },

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,0 +1,66 @@
+/// Utilities to allow parsing large integers
+///
+/// This feature is not available for PyPy or when Py_LIMITED_API is set.
+use pyo3::prelude::*;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub struct ParseIntError {
+    pub message: String
+}
+
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+use num_bigint::BigInt;
+
+pub enum AppropriateInt {
+    Normal(i64),
+    Big(BigInt),
+}
+
+#[cfg(all(any(Py_LIMITED_API, PyPy)))]
+pub enum AppropriateInt {
+    Normal(i64),
+}
+
+#[cfg(all())]
+impl FromStr for AppropriateInt {
+    type Err = ParseIntError;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<AppropriateInt, ParseIntError> {
+        match s.parse::<i64>() {
+            Ok(parsed_num) => {
+                Ok(AppropriateInt::Normal(parsed_num))
+            },
+            Err(e) if e.to_string().contains("number too") => {
+                #[cfg(all(not(any(Py_LIMITED_API, PyPy))))]
+                match BigInt::from_str(s) {
+                    Ok(parsed_num) => Ok(AppropriateInt::Big(parsed_num)),
+                    Err(e) => Err(ParseIntError{message: format!("{e:?}")}),
+                }
+                #[cfg(all(any(Py_LIMITED_API, PyPy)))]
+                {
+                    e
+                }
+            }
+            Err(e) => {
+                Err(ParseIntError{message: format!("{e:?}")})
+            }
+        }
+    }
+}
+
+#[cfg(all())]
+impl IntoPy<PyObject> for AppropriateInt {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        #![cfg(all(not(any(Py_LIMITED_API, PyPy))))]
+        match self {
+            AppropriateInt::Normal(num) => { num.into_py(py) },
+            AppropriateInt::Big(num) => { num.into_py(py) },
+        }
+        #[cfg(all(any(Py_LIMITED_API, PyPy)))]
+        match self {
+            AppropriateInt::Normal(num) => { num.into_py(py) },
+        }
+    }
+}

--- a/src/int.rs
+++ b/src/int.rs
@@ -22,7 +22,6 @@ pub enum AppropriateInt {
     Normal(i64),
 }
 
-#[cfg(all())]
 impl FromStr for AppropriateInt {
     type Err = ParseIntError;
 
@@ -33,12 +32,12 @@ impl FromStr for AppropriateInt {
                 Ok(AppropriateInt::Normal(parsed_num))
             },
             Err(e) if e.to_string().contains("number too") => {
-                #[cfg(all(not(any(Py_LIMITED_API, PyPy))))]
+                #[cfg(not(any(Py_LIMITED_API, PyPy)))]
                 match BigInt::from_str(s) {
                     Ok(parsed_num) => Ok(AppropriateInt::Big(parsed_num)),
                     Err(e) => Err(ParseIntError{message: format!("{e:?}")}),
                 }
-                #[cfg(all(any(Py_LIMITED_API, PyPy)))]
+                #[cfg(any(Py_LIMITED_API, PyPy))]
                 {
                     e
                 }
@@ -50,15 +49,14 @@ impl FromStr for AppropriateInt {
     }
 }
 
-#[cfg(all())]
 impl IntoPy<PyObject> for AppropriateInt {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        #![cfg(all(not(any(Py_LIMITED_API, PyPy))))]
+        #![cfg(not(any(Py_LIMITED_API, PyPy)))]
         match self {
             AppropriateInt::Normal(num) => { num.into_py(py) },
             AppropriateInt::Big(num) => { num.into_py(py) },
         }
-        #[cfg(all(any(Py_LIMITED_API, PyPy)))]
+        #[cfg(any(Py_LIMITED_API, PyPy))]
         match self {
             AppropriateInt::Normal(num) => { num.into_py(py) },
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,17 @@
 /// json-stream's tokenizer was originally taken from the NAYA project.
 /// https://github.com/danielyule/naya
 /// Copyright (c) 2019 Daniel Yule
-use num_bigint::{BigInt, ParseBigIntError};
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
 use pyo3_file::PyFileLikeObject;
 use std::borrow::BorrowMut;
 use std::io::BufRead;
 use std::io::BufReader;
-use std::str::FromStr;
 use utf8_chars::BufReadCharsExt;
+
+mod int;
+use crate::int::AppropriateInt;
+use std::str::FromStr;
 
 #[derive(Clone)]
 enum TokenType {
@@ -72,36 +74,6 @@ fn is_delimiter(c: char) -> bool {
 impl IntoPy<PyObject> for TokenType {
     fn into_py(self, py: Python<'_>) -> PyObject {
         (self as u32).into_py(py)
-    }
-}
-
-enum AppropriateInt {
-    Normal(i64),
-    Big(BigInt),
-}
-
-impl FromStr for AppropriateInt {
-    type Err = ParseBigIntError;
-
-    #[inline]
-    fn from_str(s: &str) -> Result<AppropriateInt, ParseBigIntError> {
-        match s.parse::<i64>() {
-            Ok(parsed_num) => {
-                Ok(AppropriateInt::Normal(parsed_num))
-            },
-            Err(_) => {
-                Ok(AppropriateInt::Big(BigInt::from_str(s)?))
-            }
-        }
-    }
-}
-
-impl IntoPy<PyObject> for AppropriateInt {
-    fn into_py(self, py: Python<'_>) -> PyObject {
-        match self {
-            AppropriateInt::Normal(num) => { num.into_py(py) },
-            AppropriateInt::Big(num) => { num.into_py(py) },
-        }
     }
 }
 

--- a/tests/test_integers.py
+++ b/tests/test_integers.py
@@ -1,0 +1,9 @@
+from io import StringIO
+from json_stream_rs_tokenizer import load
+
+
+def test_integers():
+    assert list(load(StringIO("[123]"))) == [123]
+    assert list(load(StringIO("[123e3]"))) == [123e3]
+    assert list(load(StringIO("[123E3]"))) == [123E3]
+    assert list(load(StringIO("[-123E3]"))) == [-123E3]

--- a/tests/test_large_integers.py
+++ b/tests/test_large_integers.py
@@ -1,0 +1,8 @@
+from io import StringIO
+from json_stream_rs_tokenizer import load
+
+
+def test_large_integers():
+    assert list(load(StringIO(f"[{2**63}]"))) == [2**63]
+    assert list(load(StringIO(f"[{10**200}]"))) == [10**200]
+    assert list(load(StringIO(f"[{-10**200}]"))) == [-10**200]


### PR DESCRIPTION
Fixes #13.

Parses large integers using `num-bigint` and converts them to large Python integers using PyO3's `num-bigint` extension.

So 2 new dependencies but probably worth it.

Also adds some basic tests for integer parsing in general and large integer parsing specifically.