### PR TITLE
Upload separate bin-or-dummy package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,47 +25,87 @@ jobs:
         name: wheels
         path: dist
 
-  windows:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: messense/maturin-action@v1
-      with:
-        command: build
-        args: --release -o dist --find-interpreter
-    - name: Upload wheels
-      uses: actions/upload-artifact@v2
-      with:
-        name: wheels
-        path: dist
+  #windows:
+    #runs-on: windows-latest
+    #steps:
+    #- uses: actions/checkout@v3
+    #- uses: messense/maturin-action@v1
+      #with:
+        #command: build
+        #args: --release -o dist --find-interpreter
+    #- name: Upload wheels
+      #uses: actions/upload-artifact@v2
+      #with:
+        #name: wheels
+        #path: dist
 
-  macos:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: messense/maturin-action@v1
-      with:
-        command: build
-        args: --release -o dist --universal2 --find-interpreter
-    - name: Upload wheels
-      uses: actions/upload-artifact@v2
-      with:
-        name: wheels
-        path: dist
+  #macos:
+    #runs-on: macos-latest
+    #steps:
+    #- uses: actions/checkout@v3
+    #- uses: messense/maturin-action@v1
+      #with:
+        #command: build
+        #args: --release -o dist --universal2 --find-interpreter
+    #- name: Upload wheels
+      #uses: actions/upload-artifact@v2
+      #with:
+        #name: wheels
+        #path: dist
 
-  release:
-    name: Release
+  #release:
+    #name: Release
+    #runs-on: ubuntu-latest
+    #if: "startsWith(github.ref, 'refs/tags/')"
+    #needs: [ macos, windows, linux ]
+    #steps:
+      #- uses: actions/download-artifact@v2
+        #with:
+          #name: wheels
+      #- name: Publish to PyPI
+        #uses: messense/maturin-action@v1
+        #env:
+          #MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        #with:
+          #command: upload
+          #args: --skip-existing *
+
+  release-bin-or-dummy:
+    name: Release bin-or-dummy package
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [ macos, windows, linux ]
+    #if: "startsWith(github.ref, 'refs/tags/')"
+    #needs: [ macos, windows, linux ]
+    needs: [ linux ]
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: wheels
-      - name: Publish to PyPI
+      - name: Dummify sdist
+        run: |
+          pip install toml
+          python ci/dummify-maturin-sdist.py *.tar.gz
+          shopt -s extglob
+          rm -f !(*dummy*).tar.gz
+      - name: Rename wheels
+        run: |
+          pip install wheel
+          shopt -s extglob
+          for x in !(*dummy*).whl; do
+            python ci/deep-rename-wheel.py "$x"
+            rm -f "$x"
+          done
+      - name: Move everything to be uploaded to separate folder
+        run: |
+          ls -l
+          mkdir for_upload
+          mv *.whl *.tar.gz for_upload
+          ls -l for_upload
+      - name: Publish to Test PyPI
         uses: messense/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          MATURIN_REPOSITORY_URL: https://test.pypi.org/legacy/
         with:
           command: upload
-          args: --skip-existing *
+          args: --skip-existing for_upload/*

--- a/ci/deep-rename-wheel.py
+++ b/ci/deep-rename-wheel.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+from shutil import move
+import subprocess as sp
+from sys import argv
+from tempfile import TemporaryDirectory
+
+SUFFIX = "dummy4"
+
+
+def unhyphenate(s: str):
+    return s.replace("-", "_")
+
+
+def get_one(l: list):
+    assert len(l) == 1
+    return l[0]
+
+
+if __name__ == "__main__":
+    wheel_archive_path = Path(argv[1])
+    with TemporaryDirectory() as temp_dir:
+        temp_dir_path = Path(temp_dir)
+
+        # unpack wheel to tempdir
+        sp.run(
+            ["python3", "-m", "wheel", "unpack", wheel_archive_path.absolute()],
+            cwd=temp_dir_path,
+        )
+        extracted_dirs = [x for x in temp_dir_path.iterdir() if x.is_dir()]
+        main_dir = get_one(extracted_dirs)
+
+        # get dist-info dir
+        dist_info_dir = get_one(
+            [x for x in main_dir.iterdir() if x.name.endswith(".dist-info")]
+        )
+
+        # process METADATA (equiv. of PKG-INFO in sdists)
+        # TODO find out if there is a decent module for parsing this
+        pkg_info_lines = (
+            (dist_info_dir / "METADATA").read_text().splitlines(keepends=True)
+        )
+        for i, line in enumerate(pkg_info_lines):
+            if line.startswith("Name"):
+                project_name = line.split()[1]
+                dummy_project_name = project_name + f"-{SUFFIX}"
+                # TODO do this properly, not with replace()
+                pkg_info_lines[i] = line.replace(
+                    project_name, dummy_project_name
+                )
+                break
+        with (dist_info_dir / "METADATA").open("w") as f:
+            f.writelines(pkg_info_lines)
+
+        # rename package dir
+        package_name = unhyphenate(project_name)
+        dummy_package_name = package_name + f"_{SUFFIX}"
+        move(main_dir / package_name, main_dir / dummy_package_name)
+
+        # rename dist-info dir
+        move(
+            dist_info_dir,
+            dist_info_dir.with_name(
+                # TODO do this properly, not with replace()
+                dist_info_dir.name.replace(package_name, dummy_package_name)
+            ),
+        )
+
+        # rename main dir
+        # TODO use "archive name" or sth here instead, != package_name
+        dummy_main_dir = main_dir.with_name(
+            # TODO do this properly, not with replace()
+            main_dir.name.replace(package_name, dummy_package_name)
+        )
+        move(main_dir, dummy_main_dir)
+
+        # repack as wheel
+        # TODO properly, not with replace()
+        dummy_wheel_archive_path = temp_dir_path / (
+            wheel_archive_path.name.replace(package_name, dummy_package_name)
+        )
+        sp.run(
+            ["python3", "-m", "wheel", "pack", dummy_main_dir],
+            cwd=temp_dir_path,
+        )
+
+        # move next to original wheel
+        move(
+            dummy_wheel_archive_path,
+            wheel_archive_path.parent / dummy_wheel_archive_path.name,
+        )

--- a/ci/dummify-maturin-sdist.py
+++ b/ci/dummify-maturin-sdist.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+from shutil import move, rmtree
+from sys import argv
+import tarfile
+from tempfile import TemporaryDirectory
+import toml
+
+SUFFIX = "dummy4"
+
+
+def unhyphenate(s: str):
+    return s.replace("-", "_")
+
+
+if __name__ == "__main__":
+    sdist_archive_path = Path(argv[1])
+    tar_file = tarfile.open(sdist_archive_path, "r:gz")
+    with TemporaryDirectory() as temp_dir:
+        temp_dir_path = Path(temp_dir)
+
+        # extract sdist archive to tempdir
+        tar_file.extractall(temp_dir_path)
+        extracted_dirs = [x for x in temp_dir_path.iterdir() if x.is_dir()]
+        assert len(extracted_dirs) == 1
+        main_dir = extracted_dirs[0]
+
+        # delete superfluous files
+        files_to_keep = ["LICENSE", "PKG-INFO", "pyproject.toml", "README.md"]
+        file_paths_to_keep = [main_dir / filename for filename in files_to_keep]
+        for path in main_dir.iterdir():
+            if path in file_paths_to_keep:
+                continue
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                rmtree(path)
+
+        # process pyproject.toml
+        with (main_dir / "pyproject.toml").open() as f:
+            pyproject_d = toml.load(f)
+        # build system
+        pyproject_d["build-system"]["build-backend"] = "setuptools.build_meta"
+        pyproject_d["build-system"]["requires"] = ["setuptools"]
+        # project
+        project_name = pyproject_d["project"]["name"]
+        dummy_project_name = project_name + f"-{SUFFIX}"
+        pyproject_d["project"]["name"] = dummy_project_name
+        del pyproject_d["project"]["dependencies"]
+        del pyproject_d["project"]["optional-dependencies"]
+        # packages
+        package_name = unhyphenate(project_name)
+        dummy_package_name = package_name + f"_{SUFFIX}"
+        pyproject_d["tool"] = {"setuptools": {"packages": [dummy_package_name]}}
+        with (main_dir / "pyproject.toml").open("w") as f:
+            toml.dump(pyproject_d, f)
+
+        # process PKG-INFO
+        # TODO find out if there is a decent module for parsing this
+        pkg_info_lines = (
+            (main_dir / "PKG-INFO").read_text().splitlines(keepends=True)
+        )
+        for i, line in enumerate(pkg_info_lines):
+            if line.startswith("Name"):
+                # TODO do this properly, not with replace()
+                pkg_info_lines[i] = line.replace(
+                    project_name, dummy_project_name
+                )
+                break
+        with (main_dir / "PKG-INFO").open("w") as f:
+            f.writelines(pkg_info_lines)
+
+        # create dummy package dir
+        dummy_package_dir = main_dir / dummy_package_name
+        dummy_package_dir.mkdir()
+        (dummy_package_dir / "__init__.py").touch()
+
+        # rename main dir
+        # TODO use "archive name" or sth here instead, != package_name
+        dummy_main_dir = main_dir.with_name(
+            # TODO do this properly, not with replace()
+            main_dir.name.replace(package_name, dummy_package_name)
+        )
+        move(main_dir, dummy_main_dir)
+
+        # re-archive/compress it
+        dummy_archive_path = dummy_main_dir.with_name(
+            dummy_main_dir.name + ".tar.gz"
+        )
+        with tarfile.open(dummy_archive_path, "w:gz") as dummy_tar_file:
+            dummy_tar_file.add(dummy_main_dir, arcname=dummy_main_dir.name)
+
+        # move next to original sdist
+        move(
+            dummy_archive_path,
+            sdist_archive_path.parent / dummy_archive_path.name,
+        )


### PR DESCRIPTION
Idea to circumvent pip trying to compile sdist if no prebuilt wheel available.

Installation from Test PyPI can be tested like this:

```bash
pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ json-stream-rs-tokenizer-dummy4
```