### PR TITLE
Enable arm64 builds for Mac OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
             sh -s -- -y
           CIBW_ENVIRONMENT: >
             PATH="$HOME/.cargo/bin:$PATH"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="json-stream-rs-tokenizer",
-    version="0.4.4",
+    version="0.4.5",
     rust_extensions=[
         RustExtension(
             "json_stream_rs_tokenizer.json_stream_rs_tokenizer",


### PR DESCRIPTION
Fixes issue where no prebuilt wheels were available for newer Macs