### PR TITLE
Add requires_bigint to rust_tokenizer_or_raise

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="json-stream-rs-tokenizer",
-    version="0.4.6",
+    version="0.4.7",
     rust_extensions=[
         RustExtension(
             "json_stream_rs_tokenizer.json_stream_rs_tokenizer",


### PR DESCRIPTION
Useful to have for dependent packages so they can just request everything (tokenizer + support for arb. size integers) in one call.

Fixes #30 