### PR TITLE
Use json-stream-to-standard-types for benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[benchmark,test]
-          pip install --ignore-installed git+https://github.com/smheidrich/json-stream.git@util-to-convert-to-py-std-types
+          pip install -e .[test]
       - name: Run tests
         run: |
           pytest

--- a/README.md
+++ b/README.md
@@ -106,13 +106,10 @@ from the source distribution failed).
 
 The package comes with a script for rudimentary benchmarks on randomly
 generated JSON data. To run it, you'll need to install the optional `benchmark`
-dependencies and a version of `json-stream` with
-[this patch](https://github.com/daggaz/json-stream/pull/17) applied:
+dependencies:
 
 ```bash
 pip install 'json-stream-rs-tokenizer[benchmark]'
-pip install --ignore-installed \
-  'git+https://github.com/smheidrich/json-stream.git@util-to-convert-to-py-std-types'
 ```
 
 You can then run the benchmark as follows:
@@ -125,8 +122,18 @@ Run it with `--help` to see more information.
 
 ## Tests
 
-As the tests make use of the benchmark feature, they require the same
-dependencies as above in addition to the optional `test` dependencies.
+To run the tests, you'll need to install the optional `test` dependencies:
+
+```bash
+pip install 'json-stream-rs-tokenizer[test]'
+```
+
+As the test dependencies depend on the benchmark dependencies but the feature
+enabling such
+["recursive optional dependencies"](https://hynek.me/articles/python-recursive-optional-dependencies/)
+was only introduced in Pip 21.3, you'll need a version of Pip at least as
+recent as that. For older versions, just install the test dependencies
+manually.
 
 ## License
 

--- a/json_stream_rs_tokenizer/benchmark/app.py
+++ b/json_stream_rs_tokenizer/benchmark/app.py
@@ -5,18 +5,12 @@ from tempfile import TemporaryDirectory
 
 import json_stream as js
 from contexttimer import Timer
+from json_stream_to_standard_types import to_standard_types
 from tqdm import tqdm
 
 import json_stream_rs_tokenizer as jsrs
 
 from .random_json_generator import RandomJsonGenerator
-
-try:
-    js.to_standard_types
-except AttributeError as e:
-    raise ImportError(
-        "benchmarks currently require a patched version of json-stream"
-    ) from e
 
 
 def shuffled(l):
@@ -48,9 +42,7 @@ def main(json_bytes=2e6):
             with Timer() as t:
                 with random_json_file_path.open() as f:
                     l = load_fn(f)
-                    parsed = [
-                        js.to_standard_types(x) for x in tqdm(l, total=100)
-                    ]
+                    parsed = [to_standard_types(x) for x in tqdm(l, total=100)]
             print(f"{tokenizer_type} time: {t.elapsed:.2f} s")
             results[tokenizer_type]["elapsed"] = t.elapsed
             results[tokenizer_type]["parsed"] = parsed

--- a/json_stream_rs_tokenizer/benchmark/app.py
+++ b/json_stream_rs_tokenizer/benchmark/app.py
@@ -1,10 +1,12 @@
 import json
 import random
+from functools import partial
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import json_stream as js
 from contexttimer import Timer
+from json_stream.tokenizer import tokenize as pure_python_tokenizer
 from json_stream_to_standard_types import to_standard_types
 from tqdm import tqdm
 
@@ -33,8 +35,8 @@ def main(json_bytes=2e6):
         results = {"python": {}, "rust": {}, "non-streaming": {}}
         for tokenizer_type, load_fn in shuffled(
             [
-                ("python", js.load),
-                ("rust", jsrs.load),
+                ("python", partial(js.load, tokenizer=pure_python_tokenizer)),
+                ("rust", partial(js.load, tokenizer=jsrs.RustTokenizer)),
                 ("non-streaming", json.load),
             ]
         ):

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,16 @@ setup(
     install_requires=[],
     extras_require={
         "benchmark": [
+            "json-stream-to-standard-types>=0.1,<0.2",
             "tqdm>=4.64,<5",
             "contexttimer>=0.3,<0.4",
             "si-prefix>=1.2<2",
             "typer>=0.6,<0.7",
         ],
-        "test": ["pytest>7.1,<8"],
+        "test": [
+            "pytest>7.1,<8",
+            "json-stream-rs-tokenizer[benchmark]",
+        ],
     },
     classifiers=[
         "Programming Language :: Rust",


### PR DESCRIPTION
Removes the previous dependency on a specific PR branch of json-stream introducing the same functionality.

Fixes #38 