### PR TITLE
Worst possible fix for stream overconsumption (not recommended)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,11 +100,14 @@ impl RustTokenizer {
     #[new]
     fn new(stream: PyObject) -> PyResult<Self> {
         Ok(RustTokenizer {
-            stream: Box::new(BufReader::new(
-                PyFileLikeObject::with_requirements(
-                    stream, true, false, false,
-                )?,
-            )),
+            stream: Box::new(
+                BufReader::with_capacity(
+                    4, // PyFileLikeObject divides this by 4 to get chunk size
+                    PyFileLikeObject::with_requirements(
+                        stream, true, false, false,
+                    )?,
+                )
+            ),
             completed: false,
             advance: true,
             token: String::new(),

--- a/tests/test_overconsumption.py
+++ b/tests/test_overconsumption.py
@@ -1,0 +1,24 @@
+"""
+Regression test for overconsumption of stream contents past the end of a doc:
+https://github.com/smheidrich/py-json-stream-rs-tokenizer/issues/47
+"""
+from io import StringIO
+
+import pytest
+
+from json_stream_rs_tokenizer import load
+
+
+@pytest.mark.parametrize(
+    "s,expected_cursor_pos",
+    [
+        ('{ "a": 1 } { "b": 2 }', 10),
+        ('{"a": 1} { "b": 2 }', 8),
+        ('{"a":1} { "b": 2 }', 7),
+        ('{ "a":1, "b": 2, "c": 3, "d": 4, "xyz": 99999 } { "b": 2 }', 47),
+    ],
+)
+def test_overconsumption_multiple_documents(s, expected_cursor_pos):
+    buf = StringIO(s)
+    list(load(buf))
+    assert buf.tell() == expected_cursor_pos


### PR DESCRIPTION
This fixes #47 by making the buffering machinery read only 1 character at a time. This slows things down tremendously (speedup lowered from ~10 to ~2-3) so is only for demonstration purposes or people who urgently need a fix.