### PR TITLE
Use permanent pyo3-file branch w/ buf/4 fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ pyo3-build-config = { version = "0.17.1", features = ["resolve-config"] }
 
 [patch.crates-io.pyo3-file]
 git = 'https://github.com/smheidrich/pyo3-file.git'
-branch = 'divide-buf-length-by-4-to-fix-textio-bug'
+branch = 'divide-buf-length-by-4-to-fix-textio-bug-forjsonstream'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="json-stream-rs-tokenizer",
-    version="0.4.12",
+    version="0.4.13",
     rust_extensions=[
         RustExtension(
             "json_stream_rs_tokenizer.json_stream_rs_tokenizer",


### PR DESCRIPTION
The branch I was depending on (because it fixes the [issue](https://github.com/omerbenamram/pyo3-file/issues/6) regarding UTF-8 chars not fitting into buffers) is used in a [PR](https://github.com/omerbenamram/pyo3-file/pull/7) and has to be rebased now that pyo3-file's main has been updated. I can't do that while this library still depends on it, because it could break something. So this changes the dependency to a newly created branch that's meant to preserve its current state.