### PR TITLE
Add Travis job for building other Linux archs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+os: linux
+dist: focal
+language: python
+python: "3.9"
+
+jobs:
+  include:
+    # perform a linux ARMv8 build
+    - services: docker
+      arch: arm64
+    # perform a linux PPC64LE build
+    - services: docker
+      arch: ppc64le
+    # perform a linux S390X build
+    - services: docker
+      arch: s390x
+
+install:
+  - python3 -m pip install cibuildwheel>=2.13.1,<3
+
+script:
+  # build the wheels, put them into './wheelhouse'
+  - python3 -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
Alternative idea for how to fix #60

Adapted from https://cibuildwheel.readthedocs.io/en/stable/setup/#travis-ci

Hopefully faster than #61 (Qemu@GitHub Actions, horribly slow).