### PR TITLE
Make Cargo dependency versions Renovate-processable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ name = "json_stream_rs_tokenizer"
 crate-type = ["cdylib"]
 
 [dependencies]
-num-bigint = "0.4.3"
-pyo3 = { version = "0.16.5", features = ["extension-module", "num-bigint"] }
-pyo3-file = "0.5.0"
-thiserror = "1.0.37"
-utf8-chars = "2.0.2"
+num-bigint = ">=0.4.3,<0.5"
+pyo3 = { version = ">=0.16.5,<0.17", features = ["extension-module", "num-bigint"] }
+pyo3-file = ">=0.5.0,<0.6"
+thiserror = ">=1.0.37,<2"
+utf8-chars = ">=2.0.2,<3"
 
 [build-dependencies]
 pyo3-build-config = { version = "0.17.1", features = ["resolve-config"] }

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ],
-  "rangeStrategy": "replace"
+  ]
 }


### PR DESCRIPTION
Renovate can't currently handle single dependency versions (which are actually ranges in Cargo) correctly and will bump them instead of widening as it should:
https://github.com/renovatebot/renovate/issues/20342

So we replace them with explicit ranges in the hope that it will be able to widen those.