### PR TITLE
Align Unicode parsing (esp. surrogates) w/ json-stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +77,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "errno"
@@ -149,6 +171,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 name = "json-stream-rs-tokenizer"
 version = "0.1.0"
 dependencies = [
+ "compact_str",
  "num-bigint",
  "pyo3",
  "pyo3-build-config",
@@ -366,6 +389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +475,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ pyo3 = { version = ">=0.16.5,<0.17", features = ["extension-module", "num-bigint
 pyo3-file = ">=0.5.0,<0.6"
 thiserror = ">=1.0.37,<2"
 utf8-chars = ">=2.0.2,<3"
+compact_str = ">=0.7.1,<0.8"
 
 [build-dependencies]
 pyo3-build-config = { version = "= 0.16.6", features = ["resolve-config"] }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -37,6 +37,8 @@ def test_invalid_number_starting_with_zero():
 def test_invalid_character_code():
     with pytest.raises(
         ValueError,
-        match=re.escape("Invalid character code: 'z' at index 3"),
+        match=re.escape(
+            "Unterminated unicode literal at end of file at index 5"
+        ),
     ):
         list(load(StringIO(r'"\uz"')))


### PR DESCRIPTION
Aligns (mostly) json-stream's tokenizer's Unicode parsing logic & exceptions which were reworked as part of introducing Unicode surrogates in https://github.com/daggaz/json-stream/pull/42.

Fixes #59 