### PR TITLE
Make I/O error messages more helpful

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use thiserror::Error;
 mod int;
 mod opaque_seek;
 mod park_cursor;
+mod py_err;
 mod py_bytes_stream;
 mod py_common;
 mod py_text_stream;

--- a/src/py_common.rs
+++ b/src/py_common.rs
@@ -1,6 +1,7 @@
 use pyo3::conversion::IntoPy;
 use pyo3::{PyObject, Python};
 
+#[derive(Debug, Clone, Copy)]
 pub enum PySeekWhence {
     Set = 0,
     Cur = 1,

--- a/src/py_err.rs
+++ b/src/py_err.rs
@@ -1,0 +1,36 @@
+use pyo3::{prelude::PyErr, types::PyTraceback, Python};
+/// Python error utilities.
+use std::fmt::{Display, Error, Formatter};
+
+// outer
+
+pub trait TracebackDisplay<'a> {
+    fn traceback_display(&'a self) -> Box<dyn 'a + Display>;
+}
+
+impl<'a> TracebackDisplay<'a> for PyErr {
+    fn traceback_display(&'a self) -> Box<dyn 'a + Display> {
+        Box::new(PyErrTracebackDisplayer { py_err: self })
+    }
+}
+
+// inner
+
+struct PyErrTracebackDisplayer<'a> {
+    py_err: &'a PyErr,
+}
+
+impl<'a> Display for PyErrTracebackDisplayer<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        String::fmt(
+            &Python::with_gil(|py| {
+                self.py_err.traceback(py).map_or(
+                    Ok("(no traceback available)".to_string()),
+                    PyTraceback::format,
+                )
+            })
+            .unwrap_or("(error getting traceback)".to_string()),
+            f,
+        )
+    }
+}


### PR DESCRIPTION
I/O errors originate from Python (because that's where our streams come from), so it's a good idea to include the Python tracebacks in them.

The format is quite ugly ATM (basically repr() instead of str() like output) because it goes through Rust's IO error type, but I guess fixing that would be more trouble than it's worth for now.