### PR TITLE
Include conftest.py into the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include Cargo.toml
 recursive-include src *
+include tests/conftest.py


### PR DESCRIPTION
**Context** 

In #87 a `tests/conftest.py` was added to the `tests` folder. Some tests use the fixture `to_bytes_or_str_buf` specified in `tests/conftest.py`, and therefore, the file is needed.

**Problem**

The last two source distribution tarballs do not include the `tests/conftest.py` file.

1. [json-stream-rs-tokenizer-0.4.22.tar.gz](https://pypi.io/packages/source/j/json-stream-rs-tokenizer/json-stream-rs-tokenizer-0.4.22.tar.gz)
2. [json-stream-rs-tokenizer-0.4.23.tar.gz](https://pypi.io/packages/source/j/json-stream-rs-tokenizer/json-stream-rs-tokenizer-0.4.23.tar.gz)

**Possible cause**

When creating the [source distribution](https://docs.python.org/3/distutils/sourcedist.html#specifying-the-files-to-distribute), the command `pipx run build --sdist` will only consider `test/test*.py` (and [probably](https://github.com/pypa/setuptools/blob/8ad627dfd580ac9cad2fd9c3a51dc173c5a38eca/setuptools/_distutils/command/sdist.py#L233-L253) also `tests/test*.py`) as far as it concerns [the test scripts](https://packaging.python.org/en/latest/guides/using-manifest-in/#how-files-are-included-in-an-sdist).

**Suggestion**:
- include explicitly the `tests/conftest.py` using the `MANIFEST.in` configuration file.