### PR TITLE
Fix handling of text file cursor positions (mainly on Windows)

### DIFF
--- a/src/opaque_seek.rs
+++ b/src/opaque_seek.rs
@@ -1,12 +1,8 @@
 use std::io;
 
-/// It is an error to do arithmetic on this number.
 #[derive(Copy, Clone)]
-pub struct OpaqueSeekPos(pub u64);
-
-#[derive(Copy, Clone)]
-pub enum OpaqueSeekFrom {
-    Start(OpaqueSeekPos),
+pub enum OpaqueSeekFrom<P> {
+    Start(P),
     #[allow(dead_code)] // to be honest I don't understand why this is dead code if it's public...
     End,
     Current,
@@ -21,5 +17,8 @@ pub enum OpaqueSeekFrom {
 /// other position e.g. by adding numbers to one or making one up results in
 /// undefined behavior. So don't do that.
 pub trait OpaqueSeek {
-    fn seek(&mut self, pos: OpaqueSeekFrom) -> io::Result<OpaqueSeekPos>;
+    type OpaqueSeekPos;
+
+    fn seek(&mut self, pos: OpaqueSeekFrom<Self::OpaqueSeekPos>)
+        -> io::Result<Self::OpaqueSeekPos>;
 }

--- a/src/suitable_seekable_buffered_text_stream.rs
+++ b/src/suitable_seekable_buffered_text_stream.rs
@@ -1,6 +1,6 @@
-use crate::opaque_seek::{OpaqueSeek, OpaqueSeekFrom, OpaqueSeekPos};
+use crate::opaque_seek::{OpaqueSeek, OpaqueSeekFrom};
 use crate::park_cursor::ParkCursorChars;
-use crate::py_text_stream::PyTextStream;
+use crate::py_text_stream::{PyOpaqueSeekPos, PyTextStream};
 use crate::read_string::ReadString;
 use crate::remainder::{Remainder, StreamData};
 use crate::utf8_char_source::Utf8CharSource;
@@ -16,7 +16,7 @@ pub struct SuitableSeekableBufferedTextStream {
     buffer_size: usize,
     chars_iter: OwnedChars,
     chars_read_from_buf: usize,
-    buf_start_seek_pos: Option<OpaqueSeekPos>,
+    buf_start_seek_pos: Option<PyOpaqueSeekPos>,
 }
 
 impl SuitableSeekableBufferedTextStream {
@@ -55,8 +55,8 @@ impl Utf8CharSource for SuitableSeekableBufferedTextStream {
 impl ParkCursorChars for SuitableSeekableBufferedTextStream {
     fn park_cursor(&mut self) -> io::Result<()> {
         let chars_read_from_buf = self.chars_read_from_buf;
-        if let Some(buf_start_seek_pos) = self.buf_start_seek_pos {
-            self.inner.seek(OpaqueSeekFrom::Start(buf_start_seek_pos))?;
+        if let Some(buf_start_seek_pos) = &self.buf_start_seek_pos {
+            self.inner.seek(OpaqueSeekFrom::Start(buf_start_seek_pos.clone()))?;
             self.inner.read_string(chars_read_from_buf)?;
             self.chars_iter = OwnedChars::from_string("".to_owned());
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from io import BytesIO, StringIO
+from io import SEEK_CUR, SEEK_END, BytesIO, StringIO
 
 import pytest
 
@@ -9,7 +9,14 @@ class StringIOWithLargeCursorPositions(StringIO):
     """
 
     def seek(self, offset, whence):
-        return super().seek(offset, whence) + 2**64
+        input_offset, output_offset = 0, 0
+        if offset != 0:
+            input_offset = - 2**64
+        if whence == SEEK_CUR:
+            output_offset = 2**64
+        if whence == SEEK_END:
+            raise NotImplementedError("...")
+        return super().seek(offset + input_offset, whence) + output_offset
 
     def tell(self):
         return super().tell() + 2**64

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,27 @@ from io import BytesIO, StringIO
 import pytest
 
 
-@pytest.fixture(params=["str", "bytes", "str-unseekable", "bytes-unseekable"])
+class StringIOWithLargeCursorPositions(StringIO):
+    """
+    Simulates very large (> 2^64) cursor positions as occur on Windows.
+    """
+
+    def seek(self, offset, whence):
+        return super().seek(offset, whence) + 2**64
+
+    def tell(self):
+        return super().tell() + 2**64
+
+
+@pytest.fixture(
+    params=[
+        "str",
+        "bytes",
+        "str-unseekable",
+        "bytes-unseekable",
+        "str-largecursorpos",
+    ]
+)
 def to_bytes_or_str_buf(request):
     if request.param == "str":
         return lambda s: StringIO(s)
@@ -15,6 +35,8 @@ def to_bytes_or_str_buf(request):
             return sio
 
         return make_unseekable_stringio
+    elif request.param == "str-largecursorpos":
+        return lambda s: StringIOWithLargeCursorPositions(s)
     elif request.param == "bytes":
         return lambda s: BytesIO(s.encode("utf-8"))
     elif request.param == "bytes-unseekable":

--- a/tests/test_buffering.py
+++ b/tests/test_buffering.py
@@ -31,7 +31,13 @@ def test_buffering_cursor_pos(
     else:
         assert False, "didn't find expected list elem for some reason"
     if isinstance(buf, StringIO):
-        assert buf.tell() == expected_str_cursor_pos
+        # for text streams, tell() and seek() positions are opaque numbers
+        # => compare by checking equality to position after reading N chars
+        pos = buf.tell()
+        buf.seek(0, 0)  # go back to start
+        buf.read(expected_str_cursor_pos)  # read N chars
+        expected_str_cursor_opaque_pos = buf.tell()
+        assert pos == expected_str_cursor_opaque_pos
     elif isinstance(buf, BytesIO):
         assert buf.tell() == expected_bytes_cursor_pos
     else:
@@ -73,7 +79,13 @@ def test_buffering_cursor_pos_with_correct_cursor_enforcement(
     else:
         assert False, "didn't find expected list elem for some reason"
     if isinstance(buf, StringIO):
-        assert buf.tell() == 7
+        # for text streams, tell() and seek() positions are opaque numbers
+        # => compare by checking equality to position after reading N chars
+        pos = buf.tell()
+        buf.seek(0, 0)  # go back to start
+        buf.read(7)  # read N chars
+        expected_str_cursor_opaque_pos = buf.tell()
+        assert pos == expected_str_cursor_opaque_pos
     elif isinstance(buf, BytesIO):
         assert buf.tell() == 10
     else:

--- a/tests/test_overconsumption.py
+++ b/tests/test_overconsumption.py
@@ -63,7 +63,13 @@ def test_overconsumption_park_cursor_skip_3_chars_and_continue(
             break
     tokenizer.park_cursor()
     if isinstance(buf, StringIO):
-        assert buf.tell() == expected_str_cursor_pos
+        # for text streams, tell() and seek() positions are opaque numbers
+        # => compare by checking equality to position after reading N chars
+        pos = buf.tell()
+        buf.seek(0, 0)  # go back to start
+        buf.read(expected_str_cursor_pos)  # read N chars
+        expected_str_cursor_opaque_pos = buf.tell()
+        assert pos == expected_str_cursor_opaque_pos
     elif isinstance(buf, BytesIO):
         assert buf.tell() == expected_bytes_cursor_pos
     else:


### PR DESCRIPTION
This should fix the issue described in #93 by allowing arbitrary Python objects as text file cursor (seek) positions instead of `u64` as before.

Such positions were already correctly being treated as opaque numbers, but on Windows, they are not only opaque but also arbitrarily large. Another option would have been to use arbitrary-size integers instead of fully arbitrary Python objects, but then we'd run into the problems from #14 regarding system support again. So I think arbitrary Python objects is the most portable option for now.

Involved a bit of refactoring of the `OpaqueSeek` trait that should have been done from the start (associated type to make it generic).