### PR TITLE
Fix handling of unbuffered byte streams that split UTF-8 char across read() calls

### DIFF
--- a/tests/test_load_iterable.py
+++ b/tests/test_load_iterable.py
@@ -1,0 +1,26 @@
+"""
+Test compatibility with json-stream's support for giving iterables to `load()`.
+"""
+import json_stream
+import pytest
+
+
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 4, 10])
+def test_chunk_boundary_inside_utf8_char(chunk_size: int) -> None:
+    """
+    Test that chunk boundaries inside UTF-8 chars are handled correctly.
+
+    Regression test for https://github.com/daggaz/json-stream/issues/59.
+    """
+    inner_str = "——"
+    document_str = f'"{inner_str}"'
+    document_bytes = document_str.encode("utf-8")
+
+    iterable = (
+        document_bytes[i : i + chunk_size]
+        for i in range(0, len(document_bytes), chunk_size)
+    )
+
+    parsed = json_stream.load(iterable)
+
+    assert parsed == inner_str


### PR DESCRIPTION
https://github.com/daggaz/json-stream/issues/59 ran into an issue with json-stream's feature allowing users to pass iterables of bytes to `load`, which makes it wrap them in a `RawIOBase` interface that pulls data from these iterables when read.

This exposed a more general bug in json-stream-rs-tokenizer when it comes to handling unbuffered byte streams that return UTF-8 chars split across multiple `read()` calls.

This adds a regression test for the specific case that brought this up and fixes it.

In the future, I should add lower-level tests to ensure that situations like this are handled correctly for all other kinds of streams as well, not just unbuffered bytes.