### PR TITLE
Publish wheels for Python 3.13, fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             TWINE_USERNAME: __token__
           command: |
             # install deps
-            python3 -m pip install --user cibuildwheel==2.16.5 twine
+            python3 -m pip install --user cibuildwheel==2.23.0 twine
             # build wheels
             python3 -m cibuildwheel --output-dir wheelhouse
             # upload wheels to PyPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
             CARGO_HOME_UNIX="$HOME/.cargo"
             RUSTUP_HOME_UNIX="$HOME/.rustup"
             CARGO_TARGET_DIR_UNIX="$HOME/target"
+            MACOSX_DEPLOYMENT_TARGET="10.12"
           CIBW_ENVIRONMENT_WINDOWS: >
             HOST_HOME_DIR="$HOME"
             HOST_PROJ_DIR="$GITHUB_WORKSPACE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,18 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-13]
         cibw-build-prefix: ['*']
+        cibw-build-kind: [all]  # for artifact name only
         include:
           - os: ubuntu-20.04
             cibw-build-prefix: cp*
+            cibw-build-kind: cp
           - os: ubuntu-20.04
             cibw-build-prefix: pp*
+            cibw-build-kind: pp
         exclude:
           - os: ubuntu-20.04
             cibw-build-prefix: '*'
+            cibw-build-kind: all
     steps:
       - uses: actions/checkout@v4
       - name: Restore mtimes of files in repo
@@ -126,6 +130,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ runner.os }}-${{ matrix.cibw-build-kind }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -141,6 +146,7 @@ jobs:
         run: postprocess-sdist-make-rust-ext-opt -fO dist dist/*.tar.gz
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-source
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -150,7 +156,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: artifact-*
+          merge-multiple: true
           path: dist
       - uses: pypa/gh-action-pypi-publish@v1.5.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           cat "$GITHUB_ENV"
         shell: bash
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.23.0
         env:
           CIBW_BUILD: >
             ${{ matrix.cibw-build-prefix }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,11 @@ jobs:
           - os: ubuntu-20.04
             cibw-build-prefix: '*'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Restore mtimes of files in repo
         uses: chetan/git-restore-mtime-action@v1.2
       - name: Cargo home cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cargo-home
         with:
@@ -45,7 +45,7 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.cibw-build-prefix }}-v10.
       - name: Rust build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: rust-build
         with:
@@ -123,7 +123,7 @@ jobs:
             {delocate_archs} -w {dest_dir} {wheel};
             bash $PROJ_DIR/ci-utils/after-build.sh
           CIBW_BUILD_VERBOSITY: 1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -131,14 +131,14 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build sdist
         run: pipx run build --sdist
       - name: Install tool to post-process sdist to make extension optional
         run: pip install 'postprocess-sdist-make-rust-ext-opt>=0.2,<0.3'
       - name: Post-process sdist to make extension optional
         run: postprocess-sdist-make-rust-ext-opt -fO dist dist/*.tar.gz
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,18 +41,18 @@ jobs:
           cache-name: cargo-home
         with:
           path: ~/cargo-home-dirs
-          key: ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.cibw-build-prefix }}-v10.0
+          key: ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.cibw-build-prefix }}-v11.0
           restore-keys: |
-            ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.cibw-build-prefix }}-v10.
+            ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.cibw-build-prefix }}-v11.
       - name: Rust build cache
         uses: actions/cache@v4
         env:
           cache-name: rust-build
         with:
           path: ~/cargo-target-dirs
-          key: ${{ env.cache-name }}-${{ runner.os }}-v10.0-${{ matrix.cibw-build-prefix }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ env.cache-name }}-${{ runner.os }}-v11.0-${{ matrix.cibw-build-prefix }}-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.cibw-build-prefix }}-v10.
+            ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.cibw-build-prefix }}-v11.
       - name: Save env vars for cibuildwheel
         run: >
           echo "MAIN_DIR=$PWD" >> "$GITHUB_ENV";

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,13 +32,13 @@ jobs:
             python-version: "pypy3.9"
             path: ~/.cache/pip
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Restore Rust/Cargo cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -48,7 +48,7 @@ jobs:
             target/
           key: ${{ runner.os }}-rust-v4-${{ hashFiles('**/Cargo.lock') }}
       - name: Restore Python/pip cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ matrix.path }}
           key: ${{ runner.os }}-python-v3-${{ hashFiles('**/requirements.txt') }}
@@ -68,7 +68,7 @@ jobs:
         run: |
           pytest
       - name: Save Rust/Cargo cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           path: |
@@ -79,7 +79,7 @@ jobs:
             target/
           key: ${{ runner.os }}-rust-v4-${{ hashFiles('**/Cargo.lock') }}
       - name: Save Python/pip cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           path: ${{ matrix.path }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.17.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.17.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.17.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.17.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,13 +342,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.16.6"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0220c44442c9b239dd4357aa856ac468a4f5e1f0df19ddb89b2522952eb4c6ca"
+checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
+ "memoffset",
  "num-bigint",
  "parking_lot",
  "pyo3-build-config",
@@ -350,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.16.6"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c819d397859445928609d0ec5afc2da5204e0d0f73d6bf9e153b04e83c9cdc2"
+checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -360,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.16.6"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca882703ab55f54702d7bfe1189b41b0af10272389f04cae38fe4cd56c65f75f"
+checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -370,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.16.6"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568749402955ad7be7bad9a09b8593851cd36e549ac90bfd44079cea500f3f21"
+checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -382,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.16.6"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611f64e82d98f447787e82b8e7b0ebc681e1eb78fc1252668b2c605ffb4e1eb8"
+checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 num-bigint = ">=0.4.3,<0.5"
 owned_chars = ">=0.3.2,<0.4"
-pyo3 = { version = ">=0.16.5,<0.17", features = ["num-bigint"] }
+pyo3 = { version = ">=0.17,<0.18", features = ["num-bigint"] }
 thiserror = ">=1.0.37,<2"
 utf8-chars = ">=2.0.2,<3"
 compact_str = ">=0.7.1,<0.8"
@@ -24,7 +24,7 @@ utf8-width = ">=0.1.6,<0.2"
 rstest = ">=0.18.1,<0.19"
 
 [build-dependencies]
-pyo3-build-config = { version = "= 0.16.6", features = ["resolve-config"] }
+pyo3-build-config = { version = "= 0.17.3", features = ["resolve-config"] }
 
 # workaround for linkage errors when running cargo test:
 # https://pyo3.rs/v0.18.1/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 num-bigint = ">=0.4.3,<0.5"
 owned_chars = ">=0.3.2,<0.4"
-pyo3 = { version = ">=0.17,<0.18", features = ["num-bigint"] }
+pyo3 = { version = ">=0.18,<0.19", features = ["num-bigint"] }
 thiserror = ">=1.0.37,<2"
 utf8-chars = ">=2.0.2,<3"
 compact_str = ">=0.7.1,<0.8"
@@ -24,7 +24,7 @@ utf8-width = ">=0.1.6,<0.2"
 rstest = ">=0.18.1,<0.19"
 
 [build-dependencies]
-pyo3-build-config = { version = "= 0.17.3", features = ["resolve-config"] }
+pyo3-build-config = { version = "= 0.18.3", features = ["resolve-config"] }
 
 # workaround for linkage errors when running cargo test:
 # https://pyo3.rs/v0.18.1/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror

--- a/ci-utils/before-build-linux.sh
+++ b/ci-utils/before-build-linux.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# install libatomic (required for newer rustup versions to work on older
+# CentOS-based manylinux images - may have to be removed again once
+# cibuildwheel updates the default manylinux image used from 2014 to sth.
+# newer)
+yum install -y libatomic
+
 # copy file mtimes from host
 shopt -s dotglob
 cp -r -a --attributes-only "$HOST_PROJ_DIR"/* "$PROJ_DIR"/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ enum Token {
 #[pymethods]
 impl RustTokenizer {
     #[new]
-    #[args("*", buffering = -1, correct_cursor = "true")]
+    #[pyo3(signature = (stream, *, buffering = -1, correct_cursor = true))]
     fn new(stream: PyObject, buffering: i64, correct_cursor: bool) -> PyResult<Self> {
         let buffering_mode = if buffering < 0 {
             BufferingMode::DontCare


### PR DESCRIPTION
We were on an old cibuildwheel version that didn't build Python 3.13 wheels by default.

Fingers crossed that nothing breaks :crossed_fingers: 

Fixes #112 