### PR TITLE
Include Cargo.lock in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include Cargo.toml
+include Cargo.lock
 recursive-include src *
 include tests/conftest.py


### PR DESCRIPTION
Adds Cargo.lock to sdists, thus allowing reproducible builds from it (closes #120).