### PR TITLE
Add CI tests using Python 3.14 (highest-supported)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.14"]
         os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macos-13]
         include:
           # set OS-specific cache paths


### PR DESCRIPTION
Fixes #136 